### PR TITLE
メッセージ投稿機能の実装

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,21 @@
 class MessagesController < ApplicationController
   def index
+    @room = Room.find(params[:room_id])
+    @message = Message.new
+  end
+
+  def create
+    @room = Room.find(params[:room_id])
+    @message = @room.messages.new(message_params)
+    if @message.save
+      redirect_to  room_messages_path(@room)
+    else 
+      render :index, status: :unprocessable_entity
+    end 
+  end
+
+  private
+  def message_params
+    params.require(:message).permit(:content).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,7 @@ class MessagesController < ApplicationController
   def index
     @room = Room.find(params[:room_id])
     @message = Message.new
+    @messages = @room.messages.includes(:user)
   end
 
   def create
@@ -10,6 +11,7 @@ class MessagesController < ApplicationController
     if @message.save
       redirect_to  room_messages_path(@room)
     else 
+      @message = @room.messages.includes(:user)
       render :index, status: :unprocessable_entity
     end 
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,7 +2,7 @@ class RoomsController < ApplicationController
   def index
 
   end
-  
+
   def new
     @room = Room.new
   end
@@ -14,6 +14,12 @@ class RoomsController < ApplicationController
     else 
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    room = Room.find(params[:id])
+    room.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+
+  validates :content, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,7 @@
 class Room < ApplicationRecord
   has_many :room_users
   has_many :users, through: :room_users
+  has_many :messages
   
   validates :name, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,7 @@
 class Room < ApplicationRecord
-  has_many :room_users
+  has_many :room_users, dependent: :destroy
   has_many :users, through: :room_users
-  has_many :messages
+  has_many :messages, dependent: :destroy
   
   validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
 
   has_many :room_users
   has_many :rooms, through: :room_users
+  has_many :messages
 end

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -7,7 +7,8 @@
     </div>
     <div class="right-header">
       <div class="header-button">
-        <a href="#">チャットを終了する</a>
+        <%# <a href="#">チャットを終了する</a> %>
+        <%= link_to "チャットを終了する", room_path(@room), data: { turbo_method: :delete }%>
       </div>
     </div>
   </div>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -2,7 +2,7 @@
   <div class="chat-header">
     <div class="left-header">
       <div class="header-title">
-        hogefuga
+        <%=@room.name %>
       </div>
     </div>
     <div class="right-header">

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -13,37 +13,7 @@
   </div>
 
   <div class="messages">
-    <div class="message">
-      <div class="upper-message">
-        <div class="message-user">
-          Tom
-        </div>
-        <div class="message-date">
-          2020/3/31(Wed) 12:43:30
-        </div>
-      </div>
-      <div class="lower-message">
-        <div class="message-content">
-          おはよう
-        </div>
-      </div>
-    </div>
-
-    <div class="message">
-      <div class="upper-message">
-        <div class="message-user">
-          Tom
-        </div>
-        <div class="message-date">
-          2020/3/31(Wed) 12:43:30
-        </div>
-      </div>
-      <div class="lower-message">
-        <div class="message-content">
-          おはよう
-        </div>
-      </div>
-    </div>
+    <%= render partial: "message", collection: @messages %>
   </div>
 
   <%= form_with model: [@room, @message], class: "form", local: true do |f| %>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -46,14 +46,14 @@
     </div>
   </div>
 
-  <div class="form">
+  <%= form_with model: [@room, @message], class: "form", local: true do |f| %>
     <div class="form-input">
-      <input class="form-message" placeholder= "type a message">
+      <%= f.text_field :content, class: 'form-message', placeholder: 'type a message' %>
       <label class="form-image">
         <span class="image-file">画像</span>
-        <input type="file" class="hidden">
-      </label>
+        <%= f.file_field :image, class: 'hidden' %>
+      </label >
     </div>
-    <input class="form-submit" type="submit" value="送信">
-  </div>
+    <%= f.submit '送信', class: 'form-submit' %>
+  <% end %>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="message-date">
       <!-- 投稿した時刻を出力する -->
-      <%= message.created_at%>
+      <%= l message.created_at%>
 
     </div>
   </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,21 @@
+<div class="message">
+  <div class="upper-message">
+    <div class="message-user">
+      <!-- 投稿したユーザー名情報を出力する -->
+    <%= message.user.name %>
+
+    </div>
+    <div class="message-date">
+      <!-- 投稿した時刻を出力する -->
+      <%= message.created_at%>
+
+    </div>
+  </div>
+  <div class="lower-message">
+    <div class="message-content">
+      <!-- 投稿したメッセージ内容を記述する -->
+      <%= message.content%>
+
+    </div>
+  </div>
+</div>

--- a/app/views/messages/_side_bar.html.erb
+++ b/app/views/messages/_side_bar.html.erb
@@ -15,7 +15,7 @@
       <div class="room">
         <div class="room-name">
           <%# <a href="#">techroom1</a> %>
-          <%= link_to room.name %>
+          <%= link_to room.name,room_messages_path(room) %>
         </div>
       </div>
     <% end%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module ChatApp7
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   root to: "rooms#index"
 
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create]
+  resources :rooms, only: [:new, :create] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root to: "rooms#index"
 
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create] do
+  resources :rooms, only: [:new, :create, :destroy] do
     resources :messages, only: [:index, :create]
   end
 end

--- a/db/migrate/20230809104319_create_messages.rb
+++ b/db/migrate/20230809104319_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.references :room, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_08_070956) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_104319) do
+  create_table "messages", charset: "utf8", force: :cascade do |t|
+    t.string "content"
+    t.bigint "room_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
   create_table "room_users", charset: "utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "room_id", null: false
@@ -39,6 +49,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_08_070956) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
 end


### PR DESCRIPTION
# WHAT
テキストの投稿機能を実装

# WHY
テキストの投稿機能を実装すること
投稿したテキストをメッセージ一覧画面に表示させること
投稿時刻を日本時刻へ変更すること
テキストが空の状態ではテキストを送れないようにバリデーションを設定すること
現在のチャットルーム名をメッセージ一覧画面のヘッダーに表示すること
チャットルーム削除機能を実装すること
